### PR TITLE
Fix broken link to examples

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ More examples using the Python SDK
 More Examples
 -------------
 
-More specific examples are available `here <https://github.com/solidfire/solidfire-sdk-python/blob/release1.1/examples/README.rst>`__
+More specific examples are available `here <https://github.com/solidfire/solidfire-sdk-python/blob/v1.2/examples/examples.rst>`__
 
 Logging
 -------


### PR DESCRIPTION
Change to v1.2 and change file target to examples.rst (before: readme.rst - let me know if I should revert this filename change). 

It'd be better if we could use the release (version) tag to automatically direct to the right release, but I don't know if Github or RST has such a feature.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/17)
<!-- Reviewable:end -->
