### PR TITLE
Use README.md instead README.rst

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ from distutils.command.clean import clean as _clean
 
 here = os.path.abspath(os.path.dirname(__file__))
 
-with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 


### PR DESCRIPTION
```
# python3.5 setup.py build
Traceback (most recent call last):
  File "setup.py", line 20, in <module>
    with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
  File "/usr/local/lib/python3.5/codecs.py", line 895, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: '/data/solidfire-python-sdk/solidfire-sdk-python-master/README.rst'
````

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/20)
<!-- Reviewable:end -->
