### PR TITLE
Fixed issue with HTTPError catching too many errors.

### DIFF
--- a/solidfire/common/__init__.py
+++ b/solidfire/common/__init__.py
@@ -691,7 +691,13 @@ class ServiceBase(object):
             return response_raw
 
         if 'error' in response:
-            raise requests.HTTPError(str(response["error"]["code"]) + " " + response["error"]["name"] + " " + response["error"]["message"])
+            if response["error"]["code"] == 400:
+                raise requests.HTTPError(str(response["error"]["code"]) + " " + response["error"]["name"] + " " +
+                                         response["error"]["message"])
+            else:
+                raise ApiServerError(method_name,
+                                     str(response["error"]["code"]) + " " + response["error"]["name"] + " " +
+                                     response["error"]["message"])
         else:
             return model.extract(result_type, response['result'])
 


### PR DESCRIPTION
Added an extra if statement to catch what we intended the HTTPError for, and then handled the extra errors through an APIServerError Exception as per Joels tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/26)
<!-- Reviewable:end -->
