### PR TITLE
Changed CHAPSecret to allow non explicit secret parameter declaration.

### DIFF
--- a/examples/manage_accounts.rst
+++ b/examples/manage_accounts.rst
@@ -112,6 +112,17 @@ cluster:
     add_account_result = sfe.add_account(username="my-new-account", 
                                          initiator_secret=CHAPSecret(
                                              "a12To16CharValue"))
+    # The initiator and target secrets can be set many different ways
+    # Below are more examples
+    # Passing strings into add account.
+    add_account_result = sfe.add_account("my-new-account", "a12To16CharValue")
+    # Passing string into CHAPSecret() as a parameter
+    add_account_result = sfe.add_account("my-new-account", CHAPSecret("a12To16CharValue"))
+    # Explicitly setting 'secret' in CHAPSecret()
+    add_account_result = sfe.add_account("my-new-account", CHAPSecret(secret="a12To16CharValue"))
+    # Creating a kwarg for secret and passing it in
+    kwarg = {"secret":"a12To16CharValue"}
+    add_account_result = sfe.add_account("my-new-account", CHAPSecret(**kwarg))
 
     # Grab the account ID from the result object
     new_account_id = add_account_result.account_id

--- a/solidfire/custom/models.py
+++ b/solidfire/custom/models.py
@@ -24,8 +24,10 @@ class CHAPSecret(data_model.DataObject):
         documentation="A 12 - 16 character string."
     )
 
-    def __init__(self, **kwargs):
+    def __init__(self, secretInput = None, **kwargs):
         data_model.DataObject.__init__(self, **kwargs)
+        if (secretInput != None):
+            self.secret = secretInput
 
     @staticmethod
     def auto_generate():

--- a/tests/test_ChapSecret.py
+++ b/tests/test_ChapSecret.py
@@ -1,49 +1,90 @@
 from solidfire.factory import ElementFactory
 from solidfire.custom.models import CHAPSecret
+from tests.base_test import SolidFireBaseTest
 
 import logging
 from solidfire import common
 common.setLogLevel(logging.DEBUG)
 
-print("This test script assumes no accounts named below exist.")
-e = ElementFactory.create("10.117.61.129", "admin", "admin") #hardcoded clusterIP, currently targetting a 10.3 cluster
+class TestChapCreation(SolidFireBaseTest):
+    def test_should_all_have_same_init_secret(self):
+        #This test script assumes no accounts named below exist
+        e = ElementFactory.create("10.117.61.129", "admin", "admin") #hardcoded clusterIP, currently targetting a 10.3 cluster
 
-username1 = "username1"
-username2 = "username2"
-username3 = "username3"
-username4 = "username4"
-initiatorSecret = "abcde1245678"
+        username1 = "username1"
+        username2 = "username2"
+        username3 = "username3"
+        username4 = "username4"
+        initiatorSecret = "abcde1245678"
 
-chap2 = CHAPSecret(initiatorSecret)
-chap3 = CHAPSecret(secret=initiatorSecret)
-kwarg = {"secret":initiatorSecret}
-chap4 = CHAPSecret(**kwarg)
+        chap2 = CHAPSecret(initiatorSecret)
+        chap3 = CHAPSecret(secret=initiatorSecret)
+        kwarg = {"secret":initiatorSecret}
+        chap4 = CHAPSecret(**kwarg)
 
-e.add_account(username1,initiatorSecret)
-e.add_account(username2,chap2)
-e.add_account(username3,chap3)
-e.add_account(username4,chap4)
+        e.add_account(username1,initiator_secret=initiatorSecret)
+        e.add_account(username2,initiator_secret=chap2)
+        e.add_account(username3,initiator_secret=chap3)
+        e.add_account(username4,initiator_secret=chap4)
 
-a1 = e.get_account_by_name("username1")
-a2 = e.get_account_by_name("username2")
-a3 = e.get_account_by_name("username3")
-a4 = e.get_account_by_name("username4")
+        a1 = e.get_account_by_name("username1")
+        a2 = e.get_account_by_name("username2")
+        a3 = e.get_account_by_name("username3")
+        a4 = e.get_account_by_name("username4")
 
-is1 = a1.account.initiator_secret.secret
-is2 = a2.account.initiator_secret.secret
-is3 = a3.account.initiator_secret.secret
-is4 = a4.account.initiator_secret.secret
+        is1 = a1.account.initiator_secret.secret
+        is2 = a2.account.initiator_secret.secret
+        is3 = a3.account.initiator_secret.secret
+        is4 = a4.account.initiator_secret.secret
 
-#print(is1)
-#print(is2)
-#print(is3)
-#print(is4)
+        self.assertEquals(is1,is2)
+        self.assertEquals(is2,is3)
+        self.assertEquals(is3,is4)
 
-if (is1 == is2 and is2 == is3 and is3 == is4):
-    print("All secrets are the same.")
-    print("Tests succeeded")
+        #cleanup
+        e.remove_account(a1.account.account_id)
+        e.remove_account(a2.account.account_id)
+        e.remove_account(a3.account.account_id)
+        e.remove_account(a4.account.account_id)
 
-e.remove_account(a1.account.account_id)
-e.remove_account(a2.account.account_id)
-e.remove_account(a3.account.account_id)
-e.remove_account(a4.account.account_id)
+    def test_should_all_have_same_target_secret(self):
+        # This test script assumes no accounts named below exist
+        e = ElementFactory.create("10.117.61.129", "admin",
+                                  "admin")  # hardcoded clusterIP, currently targetting a 10.3 cluster
+
+        username1 = "username1"
+        username2 = "username2"
+        username3 = "username3"
+        username4 = "username4"
+        targetSecret = "abcde1245678"
+
+        chap2 = CHAPSecret(targetSecret)
+        chap3 = CHAPSecret(secret=targetSecret)
+        kwarg = {"secret": targetSecret}
+        chap4 = CHAPSecret(**kwarg)
+
+        e.add_account(username1, target_secret= targetSecret)
+        e.add_account(username2, target_secret= chap2)
+        e.add_account(username3, target_secret= chap3)
+        e.add_account(username4, target_secret= chap4)
+
+        a1 = e.get_account_by_name("username1")
+        a2 = e.get_account_by_name("username2")
+        a3 = e.get_account_by_name("username3")
+        a4 = e.get_account_by_name("username4")
+
+        ts1 = a1.account.target_secret.secret
+        ts2 = a2.account.target_secret.secret
+        ts3 = a3.account.target_secret.secret
+        ts4 = a4.account.target_secret.secret
+
+        self.assertEquals(ts1, ts2)
+        self.assertEquals(ts2, ts3)
+        self.assertEquals(ts3, ts4)
+
+        # cleanup
+        e.remove_account(a1.account.account_id)
+        e.remove_account(a2.account.account_id)
+        e.remove_account(a3.account.account_id)
+        e.remove_account(a4.account.account_id)
+

--- a/tests/test_ChapSecret.py
+++ b/tests/test_ChapSecret.py
@@ -1,0 +1,49 @@
+from solidfire.factory import ElementFactory
+from solidfire.custom.models import CHAPSecret
+
+import logging
+from solidfire import common
+common.setLogLevel(logging.DEBUG)
+
+print("This test script assumes no accounts named below exist.")
+e = ElementFactory.create("10.117.61.129", "admin", "admin") #hardcoded clusterIP, currently targetting a 10.3 cluster
+
+username1 = "username1"
+username2 = "username2"
+username3 = "username3"
+username4 = "username4"
+initiatorSecret = "abcde1245678"
+
+chap2 = CHAPSecret(initiatorSecret)
+chap3 = CHAPSecret(secret=initiatorSecret)
+kwarg = {"secret":initiatorSecret}
+chap4 = CHAPSecret(**kwarg)
+
+e.add_account(username1,initiatorSecret)
+e.add_account(username2,chap2)
+e.add_account(username3,chap3)
+e.add_account(username4,chap4)
+
+a1 = e.get_account_by_name("username1")
+a2 = e.get_account_by_name("username2")
+a3 = e.get_account_by_name("username3")
+a4 = e.get_account_by_name("username4")
+
+is1 = a1.account.initiator_secret.secret
+is2 = a2.account.initiator_secret.secret
+is3 = a3.account.initiator_secret.secret
+is4 = a4.account.initiator_secret.secret
+
+#print(is1)
+#print(is2)
+#print(is3)
+#print(is4)
+
+if (is1 == is2 and is2 == is3 and is3 == is4):
+    print("All secrets are the same.")
+    print("Tests succeeded")
+
+e.remove_account(a1.account.account_id)
+e.remove_account(a2.account.account_id)
+e.remove_account(a3.account.account_id)
+e.remove_account(a4.account.account_id)


### PR DESCRIPTION
Improved documentation for CHAPSecret() usage. manage_accounts.rst now has examples for 5 different ways to create a CHAPSecret for add_account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/38)
<!-- Reviewable:end -->
