### PR TITLE
Fixing readme for correct attributes on timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,13 +179,13 @@ unreachable):
 
 	from solidfire.factory import ElementFactory
 	sfe = ElementFactory.create("ip-address-of-cluster", "username", "password")
-	sfe.timeout(600)
+	sfe.connect_timeout(600)
 
 Read timeout (useful for extending time for a service call to return):
 
 	from solidfire.factory import ElementFactory
 	sfe = ElementFactory.create("ip-address-of-cluster", "username", "password")
-	sfe.read_timeout(600)
+	sfe.timeout(600)
 
 **License**
 -----------


### PR DESCRIPTION
As noted in Issue #36, the read_timeout has been updated a few version back to be the timeout attribute, and timeout was updated to be connect_timeout.  However, the readme was not updated to reflect these changes.

Updating to prevent anyone else from spending time trying to figure out why setting the read_timeout was resulting in an error.  Probably would be best to cherry pick this commit to master as well, but trying to follow best practices of submitting the pull request to the dev branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/39)
<!-- Reviewable:end -->
