### PR TITLE
Fix install error due to enum34 dependency using Python 3.4+, pip 19.0+, and pyproject.toml

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,18 @@ from codecs import open
 import os
 from distutils import dir_util
 from distutils.command.clean import clean as _clean
+import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
+
+install_requires = ['setuptools>=19.2', 'future>=0.15.2', 'requests>=2.9.1']
+
+# enum introduced in Python 3.4 so not required on 3.4+
+if sys.version_info < (3, 4):
+    install_requires.append('enum34>=1.1.6')
 
 
 class Clean(_clean):
@@ -75,8 +82,7 @@ setup(
 
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
 
-    install_requires=['setuptools>=19.2',
-                      'future>=0.15.2', 'enum34>=1.1.6', 'requests>=2.9.1'],
+    install_requires=install_requires,
 
     # $> pip install -e ".[dev,test, docs, release]"
     extras_require={


### PR DESCRIPTION
Fixes #48

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/solidfire/solidfire-sdk-python/49)
<!-- Reviewable:end -->
